### PR TITLE
Make SDK runnable in python 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,5 @@ docs/_build/
 # PyBuilder
 target/
 examples/live_test.py
-
+*.iml
+.idea/

--- a/profitbricks/client.py
+++ b/profitbricks/client.py
@@ -1,8 +1,9 @@
-import requests
-import json
 import base64
-import urllib
+import json
 import re
+
+import requests
+from six.moves.urllib.parse import urlencode
 
 from profitbricks import (
     API_HOST,
@@ -1527,7 +1528,7 @@ class ProfitBricksService(object):
             '/datacenters/%s/volumes/%s/create-snapshot' % (
                 datacenter_id, volume_id),
             type='POST-ACTION-JSON',
-            data=urllib.urlencode(data))
+            data=urlencode(data))
 
         resp = response.json()
 
@@ -1558,7 +1559,7 @@ class ProfitBricksService(object):
                 datacenter_id,
                 volume_id),
             type='POST-ACTION',
-            data=urllib.urlencode(data))
+            data=urlencode(data))
 
         return response
 

--- a/profitbricks/client.py
+++ b/profitbricks/client.py
@@ -1790,7 +1790,7 @@ class ProfitBricksService(object):
                 yield str.capitalize
 
         c = camelcase()
-        return "".join(c.next()(x) if x else '_' for x in value.split("_"))
+        return "".join(next(c)(x) if x else '_' for x in value.split("_"))
 
     def _create_lan_dict(self, lan):
         items = []


### PR DESCRIPTION
This PR applies [PEP 3114](https://www.python.org/dev/peps/pep-3114/) which makes is runnable on python 3.x. The syntax change is backward compatible from version 2.6