### PR TITLE
include option to check for unicode strings when creating authentication key

### DIFF
--- a/profitbricks/client.py
+++ b/profitbricks/client.py
@@ -1629,7 +1629,7 @@ class ProfitBricksService(object):
         return url
 
     def _b(self, s):
-        if isinstance(s, str):
+        if isinstance(s, str) or isinstance(s, unicode):
             return s.encode('utf-8')
         elif isinstance(s, bytes):
             return s


### PR DESCRIPTION
When creating a new instance of `ProfitBricksService` with username/password values read from a json file, they are formatted as `unicode` strings instead of `byte` strings. In the current code, this causes 
```
TypeError: Invalid argument u'user@name:pwd' for b()
```

-------
If for some reason `ProfitBricksService` didn't want to allow for `unicode` strings when forming the authentication key, there should be a check when instantiating the class, not deeper down in the execution. 