### PR TITLE
Fixing method _b() of class ProfitBricksService

### DIFF
--- a/profitbricks/client.py
+++ b/profitbricks/client.py
@@ -3,6 +3,7 @@ import json
 import re
 
 import requests
+import six
 from six.moves.urllib.parse import urlencode
 
 from profitbricks import (
@@ -1628,13 +1629,26 @@ class ProfitBricksService(object):
         url = self.host_base + uri
         return url
 
-    def _b(self, s):
-        if isinstance(s, str) or isinstance(s, unicode):
-            return s.encode('utf-8')
-        elif isinstance(s, bytes):
-            return s
+    def _b(self, s, encoding='utf-8'):
+        """
+        Returns the given string as a string of bytes. That means in
+        Python2 as a str object, and in Python3 as a bytes object.
+        Raises a TypeError, if it cannot be converted.
+        """
+        id six.PY2:
+            # This is Python2
+            if isinstance(s, str):
+                return s
+            elif isinstance(s, unicode):
+                return s.encode(encoding)
         else:
-            raise TypeError("Invalid argument %r for b()" % (s,))
+            # And this is Python3
+            if isinstance(s, bytes):
+                return s
+            elif isinstance(s, str):
+                return s.encode(encoding)
+
+        raise TypeError("Invalid argument %r for _b()" % (s,))
 
     'Used to convert python snake case back to mixed case.'
     def _underscore_to_camelcase(self, value):


### PR DESCRIPTION
* The old version would lead to a NameError exception, because
  in Python2 class 'bytes' is not known, and in Python3
  class 'unicode is not known.

```
0 fbrehm@samara:~ > ipython
Python 3.4.3 (default, Jan 18 2016, 15:27:28) 
Type "copyright", "credits" or "license" for more information.

IPython 3.2.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: s = 'kkk'

In [2]: isinstance(s, unicode)
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-2-51643d14169e> in <module>()
----> 1 isinstance(s, unicode)

NameError: name 'unicode' is not defined

In [3]:
```