### PR TITLE
catch errors when the response is not json

### DIFF
--- a/profitbricks/client.py
+++ b/profitbricks/client.py
@@ -1600,11 +1600,14 @@ class ProfitBricksService(object):
                 if response.status_code == 202:
                     return True
 
-        if not response.ok:
-            err = response.json()
-            code = err['httpStatus']
-            msg = err['messages'][0]['message']
-            raise Exception(code, msg)
+        try:
+            if not response.ok:
+                err = response.json()
+                code = err['httpStatus']
+                msg = err['messages'][0]['message']
+                raise Exception(code, msg)
+        except ValueError as e:
+            raise Exception('Failed to parse the response', response.text)
 
         json_response = response.json()
 


### PR DESCRIPTION
make it easier to find why a request fails - the previous stacktrace was obfuscating the cause of failure when the response was html

```
  File "/ENV-2.7.11/lib/python2.7/site-packages/profitbricks/client.py", line 52, in list_datacenters
    response = self._perform_request('/datacenters?depth='+str(depth))
  File "/ENV-2.7.11/lib/python2.7/site-packages/profitbricks/client.py", line 1604, in _perform_request
    err = response.json()
  File "/ENV-2.7.11/lib/python2.7/site-packages/requests/models.py", line 808, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
```