### PR TITLE
Fix flake8 issues

### DIFF
--- a/profitbricks/client.py
+++ b/profitbricks/client.py
@@ -167,7 +167,8 @@ class ProfitBricksService(object):
 
         if not password and use_keyring:
             logger = logging.getLogger(__name__)
-            question = ("Please enter your password for {} on {}: ".format(self.username, self.host_base))
+            question = ("Please enter your password for {} on {}: "
+                        .format(self.username, self.host_base))
             if HAS_KEYRING:
                 password = keyring.get_password(self.keyring_identificator, self.username)
                 if password is None:

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -230,7 +230,6 @@ class TestUserManagement(unittest.TestCase):
                          self.resource['group']['name'] + ' - RENAME')
         self.assertFalse(group['properties']['createDataCenter'])
 
-    
     def test_delete_group(self):
         group = self.client.delete_group(group_id=self.group2['id'])
 
@@ -271,13 +270,13 @@ class TestUserManagement(unittest.TestCase):
 
     def test_update_share(self):
         share = self.client.update_share(group_id=self.group3['id'],
-                                    resource_id=self.datacenter['id'],
-                                    share_privilege=False)
+                                         resource_id=self.datacenter['id'],
+                                         share_privilege=False)
 
         self.assertEqual(share['id'], self.datacenter['id'])
         self.assertEqual(share['type'], 'resource')
         self.assertFalse(share['properties']['sharePrivilege'])
-        
+
     def test_get_share_failure(self):
         try:
             self.client.get_share(group_id=self.group3['id'],


### PR DESCRIPTION
```
$ python3 -m flake8 --max-line-length=99 examples profitbricks tests setup.py
profitbricks/client.py:170:100: E501 line too long (106 > 99 characters)
tests/test_user_management.py:233:1: W293 blank line contains whitespace
tests/test_user_management.py:234:5: E303 too many blank lines (2)
tests/test_user_management.py:274:37: E128 continuation line under-indented for visual indent
tests/test_user_management.py:275:37: E128 continuation line under-indented for visual indent
tests/test_user_management.py:280:1: W293 blank line contains whitespace
```